### PR TITLE
Display Pokémon genders in-battle and on status screen.

### DIFF
--- a/constants/misc_constants.asm
+++ b/constants/misc_constants.asm
@@ -209,8 +209,3 @@ SAME_BOTH_GENDERS EQU $7F
 FEMALE_75_PERCENT EQU $BF
 FEMALE_ONLY       EQU $FE
 NO_GENDER         EQU $FF
-
-; used when returning a Pokemon's gender
-GENDERLESS EQU $00
-MALE       EQU $01
-FEMALE     EQU $02

--- a/constants/misc_constants.asm
+++ b/constants/misc_constants.asm
@@ -200,3 +200,17 @@ LINK_STATE_START_BATTLE  EQU $03 ; pre-battle initialisation
 LINK_STATE_BATTLING      EQU $04 ; in a link battle
 LINK_STATE_RESET         EQU $05 ; reset game (unused)
 LINK_STATE_TRADING       EQU $32 ; in a link trade
+
+; Used  to define gender ratios
+MALE_ONLY         EQU $00
+MALE_88_PERCENT   EQU $1F
+MALE_75_PERCENT   EQU $3F
+SAME_BOTH_GENDERS EQU $7F
+FEMALE_75_PERCENT EQU $BF
+FEMALE_ONLY       EQU $FE
+NO_GENDER         EQU $FF
+
+; used when returning a Pokemon's gender
+GENDERLESS EQU $00
+MALE       EQU $01
+FEMALE     EQU $02

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -1912,6 +1912,7 @@ DrawPlayerHUDAndHPBar:
 	ld de, wBattleMonNick
 	coord hl, 10, 7
 	call PlaceString
+	call PrintPlayerMonGender
 	call PrintEXPBar
 	ld hl, wBattleMonSpecies
 	ld de, wLoadedMon
@@ -1972,6 +1973,7 @@ DrawEnemyHUDAndHPBar:
 	coord hl, 1, 0
 	call CenterMonName
 	call PlaceString
+	call PrintEnemyMonGender
 	coord hl, 6, 1
 	push hl
 	inc hl
@@ -8723,4 +8725,40 @@ PlayBattleAnimationGotID:
 	pop bc
 	pop de
 	pop hl
+	ret
+
+PrintEnemyMonGender:
+; draw a male, female, or blank symbol for the Enemy 'mon
+	ld a, [wEnemyMonSpecies]
+	ld de, wEnemyMonDVs
+	call PrintGenderCommon
+	coord hl, 9, 1
+	ld [hl], a
+	ret
+
+PrintPlayerMonGender:
+; draw a male, female, or blank symbol for the Player 'mon
+	ld a, [wBattleMonSpecies]
+	ld de, wBattleMonDVs
+	call PrintGenderCommon
+	coord hl, 17, 8
+	ld [hl], a
+	ret
+
+PrintGenderCommon: ; used by both routines
+	ld [wd11e], a
+	callba GetMonGender
+	ld a, [wd11e]
+	and a
+	jr z, .noGender
+	dec a
+	jr z, .male
+	; else female
+	ld a, "♀"
+	ret
+.male
+	ld a, "♂"
+	ret
+.noGender
+	ld a, " "
 	ret

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -8749,16 +8749,4 @@ PrintGenderCommon: ; used by both routines
 	ld [wd11e], a
 	callba GetMonGender
 	ld a, [wd11e]
-	and a
-	jr z, .noGender
-	dec a
-	jr z, .male
-	; else female
-	ld a, "♀"
-	ret
-.male
-	ld a, "♂"
-	ret
-.noGender
-	ld a, " "
 	ret

--- a/engine/menu/status_screen.asm
+++ b/engine/menu/status_screen.asm
@@ -486,19 +486,6 @@ PrintGenderStatusScreen:
 	ld de, wLoadedMonDVs
 	callba GetMonGender
 	ld a, [wd11e]
-	and a
-	jr z, .noGender
-	dec a
-	jr z, .male
-	; else female
-	ld a, "♀"
-	jr .printSymbol
-.male
-	ld a, "♂"
-	jr .printSymbol
-.noGender
-	ld a, " "
-.printSymbol
 	coord hl, 17, 2
 	ld [hl], a
 	ret

--- a/engine/menu/status_screen.asm
+++ b/engine/menu/status_screen.asm
@@ -164,6 +164,7 @@ StatusScreen:
 	ld de, wLoadedMonOTID
 	lb bc, LEADING_ZEROES | 2, 5
 	call PrintNumber ; ID Number
+	call PrintGenderStatusScreen
 	ld d, $0
 	call PrintStatsBox
 	call Delay3
@@ -477,4 +478,27 @@ StatusScreen_PrintPP:
 	add hl, de
 	dec c
 	jr nz, StatusScreen_PrintPP
+	ret
+
+PrintGenderStatusScreen:
+	ld a, [wLoadedMonSpecies]
+	ld [wd11e], a
+	ld de, wLoadedMonDVs
+	callba GetMonGender
+	ld a, [wd11e]
+	and a
+	jr z, .noGender
+	dec a
+	jr z, .male
+	; else female
+	ld a, "♀"
+	jr .printSymbol
+.male
+	ld a, "♂"
+	jr .printSymbol
+.noGender
+	ld a, " "
+.printSymbol
+	coord hl, 17, 2
+	ld [hl], a
 	ret

--- a/engine/mon_gender.asm
+++ b/engine/mon_gender.asm
@@ -44,13 +44,13 @@ GetMonGender::
 	jr c, .male
 
 .female
-	ld a, FEMALE
+	ld a, "♀" ; FEMALE
 	jr .done
 .male
-	ld a, MALE
+	ld a, "♂" ; MALE
 	jr .done
 .genderless
-	ld a, GENDERLESS
+	ld a, " " ; GENDERLESS
 .done
 	ld [wd11e], a
 	ret

--- a/engine/mon_gender.asm
+++ b/engine/mon_gender.asm
@@ -1,0 +1,209 @@
+; Determine a Pokémon's gender based on its DVs
+; This uses the same formula as Gen 2, so gender should match if you trade them forward via Time Capsule
+; INPUTS - Mon DVs in de, species in wd11e
+; OUTPUT - Mon's gender in wd11e
+GetMonGender::
+	push de
+	predef IndexToPokedex
+	pop de
+	ld a, [wd11e]
+	dec a
+	ld c, a
+	ld b, 0
+	ld hl, MonGenderRatios
+	add hl, bc ; hl now points to the species gender ratio
+
+; Attack DV
+	ld a, [de]
+	and $f0
+	ld b, a
+; Speed DV
+	inc de
+	ld a, [de]
+	and $f0
+	swap a
+; Put them together
+	or b
+	ld b, a ; b now has the combined DVs
+
+; Get the gender ratio
+	ld a, [hl]
+
+; Check for always one or another
+	cp NO_GENDER
+	jr z, .genderless
+
+	cp FEMALE_ONLY
+	jr z, .female
+
+	and a ; MALE_ONLY
+	jr z, .male
+
+; Compare the ratio to the value we found earlier
+	cp b
+	jr c, .male
+
+.female
+	ld a, FEMALE
+	jr .done
+.male
+	ld a, MALE
+	jr .done
+.genderless
+	ld a, GENDERLESS
+.done
+	ld [wd11e], a
+	ret
+
+MonGenderRatios:
+	db MALE_88_PERCENT   ; Bulbasaur
+	db MALE_88_PERCENT   ; Ivysaur
+	db MALE_88_PERCENT   ; Venusaur
+	db MALE_88_PERCENT   ; Charmander
+	db MALE_88_PERCENT   ; Charmeleon
+	db MALE_88_PERCENT   ; Charizard
+	db MALE_88_PERCENT   ; Squirtle
+	db MALE_88_PERCENT   ; Wartortle
+	db MALE_88_PERCENT   ; Blastoise
+	db SAME_BOTH_GENDERS ; Caterpie
+	db SAME_BOTH_GENDERS ; Metapod
+	db SAME_BOTH_GENDERS ; Butterfree
+	db SAME_BOTH_GENDERS ; Weedle
+	db SAME_BOTH_GENDERS ; Kakuna
+	db SAME_BOTH_GENDERS ; Beedrill
+	db SAME_BOTH_GENDERS ; Pidgey
+	db SAME_BOTH_GENDERS ; Pidgeotto
+	db SAME_BOTH_GENDERS ; Pidgeot
+	db SAME_BOTH_GENDERS ; Rattata
+	db SAME_BOTH_GENDERS ; Raticate
+	db SAME_BOTH_GENDERS ; Spearow
+	db SAME_BOTH_GENDERS ; Fearow
+	db SAME_BOTH_GENDERS ; Ekans
+	db SAME_BOTH_GENDERS ; Arbok
+	db SAME_BOTH_GENDERS ; Pikachu
+	db SAME_BOTH_GENDERS ; Raichu
+	db SAME_BOTH_GENDERS ; Sandshrew
+	db SAME_BOTH_GENDERS ; Sandslash
+	db FEMALE_ONLY       ; Nidoran F
+	db FEMALE_ONLY       ; Nidorina
+	db FEMALE_ONLY       ; Nidoqueen
+	db MALE_ONLY         ; Nidoran M
+	db MALE_ONLY         ; Nidorino
+	db MALE_ONLY         ; Nidoking
+	db FEMALE_75_PERCENT ; Clefairy
+	db FEMALE_75_PERCENT ; Clefable
+	db FEMALE_75_PERCENT ; Vulpix
+	db FEMALE_75_PERCENT ; Ninetales
+	db FEMALE_75_PERCENT ; Jigglypuff
+	db FEMALE_75_PERCENT ; WIgglytuff
+	db SAME_BOTH_GENDERS ; Zubat
+	db SAME_BOTH_GENDERS ; Golbat
+	db SAME_BOTH_GENDERS ; Oddish
+	db SAME_BOTH_GENDERS ; Gloom
+	db SAME_BOTH_GENDERS ; Vileplume
+	db SAME_BOTH_GENDERS ; Paras
+	db SAME_BOTH_GENDERS ; Parasect
+	db SAME_BOTH_GENDERS ; Venonat
+	db SAME_BOTH_GENDERS ; Venomoth
+	db SAME_BOTH_GENDERS ; Diglett
+	db SAME_BOTH_GENDERS ; Dugtrio
+	db SAME_BOTH_GENDERS ; Meowth
+	db SAME_BOTH_GENDERS ; Persian
+	db SAME_BOTH_GENDERS ; Psyduck
+	db SAME_BOTH_GENDERS ; Golduck
+	db SAME_BOTH_GENDERS ; Mankey
+	db SAME_BOTH_GENDERS ; Primeape
+	db MALE_75_PERCENT   ; Growlithe
+	db MALE_75_PERCENT   ; Arcanine
+	db SAME_BOTH_GENDERS ; Poliwag
+	db SAME_BOTH_GENDERS ; Poliwhirl
+	db SAME_BOTH_GENDERS ; Poliwrath
+	db MALE_75_PERCENT   ; Abra
+	db MALE_75_PERCENT   ; Kadabra
+	db MALE_75_PERCENT   ; Alakazam
+	db MALE_75_PERCENT   ; Machop
+	db MALE_75_PERCENT   ; Machoke
+	db MALE_75_PERCENT   ; Machamp
+	db SAME_BOTH_GENDERS ; Bellsprout
+	db SAME_BOTH_GENDERS ; Weepinbell
+	db SAME_BOTH_GENDERS ; Victreebel
+	db SAME_BOTH_GENDERS ; Tentacool
+	db SAME_BOTH_GENDERS ; Tentacruel
+	db SAME_BOTH_GENDERS ; Geodude
+	db SAME_BOTH_GENDERS ; Graveler
+	db SAME_BOTH_GENDERS ; Golem
+	db SAME_BOTH_GENDERS ; Ponyta
+	db SAME_BOTH_GENDERS ; Rapidash
+	db SAME_BOTH_GENDERS ; Slowpoke
+	db SAME_BOTH_GENDERS ; Slowbro
+	db NO_GENDER         ; Magnemite
+	db NO_GENDER         ; Magneton
+	db SAME_BOTH_GENDERS ; Farfetch'd
+	db SAME_BOTH_GENDERS ; Doduo
+	db SAME_BOTH_GENDERS ; Dodrio
+	db SAME_BOTH_GENDERS ; Seel
+	db SAME_BOTH_GENDERS ; Dewgong
+	db SAME_BOTH_GENDERS ; Grimer
+	db SAME_BOTH_GENDERS ; Muk
+	db SAME_BOTH_GENDERS ; Shellder
+	db SAME_BOTH_GENDERS ; Cloyster
+	db SAME_BOTH_GENDERS ; Gastly
+	db SAME_BOTH_GENDERS ; Haunter
+	db SAME_BOTH_GENDERS ; Gengar
+	db SAME_BOTH_GENDERS ; Onix
+	db SAME_BOTH_GENDERS ; Drowzee
+	db SAME_BOTH_GENDERS ; Hypno
+	db SAME_BOTH_GENDERS ; Krabby
+	db SAME_BOTH_GENDERS ; Kingler
+	db NO_GENDER         ; Voltorb
+	db NO_GENDER         ; Electrode
+	db SAME_BOTH_GENDERS ; Exeggcute
+	db SAME_BOTH_GENDERS ; Exeggutor
+	db SAME_BOTH_GENDERS ; Cubone
+	db SAME_BOTH_GENDERS ; Marowak
+	db MALE_ONLY         ; Hitmonlee
+	db MALE_ONLY         ; Hitmonchan
+	db SAME_BOTH_GENDERS ; Lickitung
+	db SAME_BOTH_GENDERS ; Koffing
+	db SAME_BOTH_GENDERS ; Weezing
+	db SAME_BOTH_GENDERS ; Rhyhorn
+	db SAME_BOTH_GENDERS ; Rhydon
+	db FEMALE_ONLY       ; Chansey
+	db SAME_BOTH_GENDERS ; Tangela
+	db FEMALE_ONLY       ; Kangaskhan
+	db SAME_BOTH_GENDERS ; Horsea
+	db SAME_BOTH_GENDERS ; Seadra
+	db SAME_BOTH_GENDERS ; Goldeen
+	db SAME_BOTH_GENDERS ; Seaking
+	db NO_GENDER         ; Staryu
+	db NO_GENDER         ; Starmie
+	db SAME_BOTH_GENDERS ; Mr. Mime
+	db SAME_BOTH_GENDERS ; Scyther
+	db FEMALE_ONLY       ; Jynx
+	db MALE_75_PERCENT   ; Electabuzz
+	db MALE_75_PERCENT   ; Magmar
+	db SAME_BOTH_GENDERS ; Pinsir
+	db MALE_ONLY         ; Tauros
+	db SAME_BOTH_GENDERS ; Magikarp
+	db SAME_BOTH_GENDERS ; Gyarados
+	db SAME_BOTH_GENDERS ; Lapras
+	db NO_GENDER         ; Ditto
+	db MALE_88_PERCENT   ; Eevee
+	db MALE_88_PERCENT   ; Vaporeon
+	db MALE_88_PERCENT   ; Jolteon
+	db MALE_88_PERCENT   ; Flareon
+	db NO_GENDER         ; Porygon
+	db MALE_88_PERCENT   ; Omanyte
+	db MALE_88_PERCENT   ; Omastar
+	db MALE_88_PERCENT   ; Kabuto
+	db MALE_88_PERCENT   ; Kabutops
+	db MALE_88_PERCENT   ; Aerodactyl
+	db MALE_88_PERCENT   ; Snorlax
+	db NO_GENDER         ; Articuno
+	db NO_GENDER         ; Zapdos
+	db NO_GENDER         ; Moltres
+	db SAME_BOTH_GENDERS ; Dratini
+	db SAME_BOTH_GENDERS ; Dragonair
+	db SAME_BOTH_GENDERS ; Dragonite
+	db NO_GENDER         ; Mewtwo
+	db NO_GENDER         ; Mew

--- a/main.asm
+++ b/main.asm
@@ -7055,3 +7055,4 @@ MewPicBack::          INCBIN "pic/monback/mewb.pic"
 SECTION "bank2F",ROMX,BANK[$2F]
 
 INCLUDE "data/super_palettes.asm"
+INCLUDE "engine/mon_gender.asm"


### PR DESCRIPTION
Should use the same formula and gender ratios as Gen II. As such, the gender shouldn't randomly change during gameplay or if a Pokémon is traded forward to Gen II via the Time Capsule (same goes for trading one back in time from Gen II).